### PR TITLE
fix: remove db files on boot

### DIFF
--- a/grype-server/cmd/grype-server/main.go
+++ b/grype-server/cmd/grype-server/main.go
@@ -2,13 +2,15 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"os/signal"
+	"path"
+	"strconv"
 	"syscall"
 
 	"github.com/Portshift/go-utils/healthz"
 	logutils "github.com/Portshift/go-utils/log"
+	"github.com/anchore/grype/grype/vulnerability"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 	"github.com/urfave/cli"
@@ -24,7 +26,7 @@ func run(c *cli.Context) {
 	conf := config.LoadConfig()
 
 	// remove database directory if it exists to avoid using a corrupt database
-	dbDir := fmt.Sprintf("%s/%s", conf.DbRootDir, conf.DbDirName)
+	dbDir := path.Join(conf.DbRootDir, strconv.Itoa(vulnerability.SchemaVersion))
 	if _, err := os.Stat(dbDir); !os.IsNotExist(err) {
 		if err = os.RemoveAll(dbDir); err != nil {
 			log.Fatalf("Unable to delete existing DB directory: %v", err)
@@ -71,7 +73,7 @@ func run(c *cli.Context) {
 func main() {
 	viper.SetDefault(config.RestServerPort, "9991")
 	viper.SetDefault(config.HealthCheckAddress, ":8080")
-	viper.SetDefault(config.DbRootDir, "/app/")
+	viper.SetDefault(config.DbRootDir, "/tmp/")
 	viper.SetDefault(config.DbUpdateURL, "https://toolbox-data.anchore.io/grype/databases/listing.json")
 	viper.SetDefault(config.DbDirName, "3")
 	viper.AutomaticEnv()

--- a/grype-server/cmd/grype-server/main.go
+++ b/grype-server/cmd/grype-server/main.go
@@ -75,7 +75,6 @@ func main() {
 	viper.SetDefault(config.HealthCheckAddress, ":8080")
 	viper.SetDefault(config.DbRootDir, "/app/")
 	viper.SetDefault(config.DbUpdateURL, "https://toolbox-data.anchore.io/grype/databases/listing.json")
-	viper.SetDefault(config.DbDirName, "3")
 	viper.AutomaticEnv()
 
 	app := cli.NewApp()

--- a/grype-server/cmd/grype-server/main.go
+++ b/grype-server/cmd/grype-server/main.go
@@ -73,7 +73,7 @@ func run(c *cli.Context) {
 func main() {
 	viper.SetDefault(config.RestServerPort, "9991")
 	viper.SetDefault(config.HealthCheckAddress, ":8080")
-	viper.SetDefault(config.DbRootDir, "/tmp/")
+	viper.SetDefault(config.DbRootDir, "/app/")
 	viper.SetDefault(config.DbUpdateURL, "https://toolbox-data.anchore.io/grype/databases/listing.json")
 	viper.SetDefault(config.DbDirName, "3")
 	viper.AutomaticEnv()

--- a/grype-server/pkg/config/config.go
+++ b/grype-server/pkg/config/config.go
@@ -10,7 +10,6 @@ const (
 	HealthCheckAddress = "HEALTH_CHECK_ADDRESS"
 	DbRootDir          = "DB_ROOT_DIR"
 	DbUpdateURL        = "DB_UPDATE_URL"
-	DbDirName          = "DB_DIR_NAME"
 )
 
 type Config struct {
@@ -19,7 +18,6 @@ type Config struct {
 	HealthCheckAddress string
 	DbRootDir          string
 	DbUpdateURL        string
-	DbDirName          string
 }
 
 func LoadConfig() *Config {
@@ -30,7 +28,6 @@ func LoadConfig() *Config {
 	config.HealthCheckAddress = viper.GetString(HealthCheckAddress)
 	config.DbRootDir = viper.GetString(DbRootDir)
 	config.DbUpdateURL = viper.GetString(DbUpdateURL)
-	config.DbDirName = viper.GetString(DbDirName)
 
 	return config
 }


### PR DESCRIPTION
## Description

In order to prevent cases of malformed db, we delete the mysql grype db when starting. 
The logic is already there, just needed to update the db folder to be aligned with grype changes.

## Type of Change

[X] Bug Fix  
[ ] New Feature  
[ ] Breaking Change  
[ ] Refactor  
[ ] Documentation  
[ ] Other (please describe)  

